### PR TITLE
Instance Launch now supports warnings and errors in API response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>com.qubell.jenkins-ci.plugins</groupId>
     <artifactId>qubell</artifactId>
     <name>Qubell Plugin</name>
-    <version>2.5</version>
+    <version>2.6</version>
     <packaging>hpi</packaging>
 
     <developers>

--- a/src/main/java/com/qubell/services/InstanceStatus.java
+++ b/src/main/java/com/qubell/services/InstanceStatus.java
@@ -163,22 +163,23 @@ public class InstanceStatus {
 
         InstanceStatus that = (InstanceStatus) o;
 
-        return application.equals(that.application)
-                && currentWorkflow == null ? that.currentWorkflow == null : currentWorkflow.equals(that.currentWorkflow)
-                && instance.equals(that.instance)
-                && returnValues == null ? that.returnValues == null : returnValues.equals(that.returnValues)
-                && status == that.status
-                && version.equals(that.version);
+        return (application == null ? that.application == null : application.equals(that.application))
+               && (currentWorkflow == null ? that.currentWorkflow == null : currentWorkflow.equals(that.currentWorkflow))
+               && (instance == null ? that.instance == null : instance.equals(that.instance))
+               && (returnValues == null ? that.returnValues == null : returnValues.equals(that.returnValues))
+               && status == that.status
+               && (version == null ? that.version == null : version.equals(that.version));
+
     }
 
     @Override
     public int hashCode() {
-        int result = instance.hashCode();
-        result = 31 * result + version.hashCode();
-        result = 31 * result + status.hashCode();
+        int result = instance != null ? instance.hashCode() : 0;
+        result = 31 * result + (version != null ? version.hashCode() : 0);
+        result = 31 * result + (status != null ? status.hashCode() : 0);
         result = 31 * result + (currentWorkflow != null ? currentWorkflow.hashCode() : 0);
         result = 31 * result + (returnValues != null ? returnValues.hashCode() : 0);
-        result = 31 * result + application.hashCode();
+        result = 31 * result + (application != null ? application.hashCode() : 0);
         return result;
     }
 }

--- a/src/main/java/com/qubell/services/ws/LaunchInstanceResponse.java
+++ b/src/main/java/com/qubell/services/ws/LaunchInstanceResponse.java
@@ -18,6 +18,7 @@ package com.qubell.services.ws;
 
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import java.util.List;
 
 /**
  * Response of instance launch WS call
@@ -28,6 +29,10 @@ import javax.xml.bind.annotation.XmlType;
 public class LaunchInstanceResponse {
 
     private String id;
+
+    private List<String> warnings;
+
+    private List<String> errors;
 
     /**
      * Gets instance id
@@ -44,4 +49,21 @@ public class LaunchInstanceResponse {
     public void setId(String id) {
         this.id = id;
     }
+
+    public List<String> getWarnings() {
+        return warnings;
+    }
+
+    public void setWarnings(List<String> warnings) {
+        this.warnings = warnings;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(List<String> errors) {
+        this.errors = errors;
+    }
+
 }


### PR DESCRIPTION
Closes #42

Impact:
- Launch instance with warnings in manifest - it should attempt to launch instead of plugin failure